### PR TITLE
Use EventEmitter/EventHandle; fully-implement

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
     "purescript-nullable": "^6.0.0",
     "purescript-options": "^7.0.0",
     "purescript-prelude": "^6.0.0",
-    "purescript-transformers": "^6.0.0"
+    "purescript-transformers": "^6.0.0",
+    "purescript-node-event-emitter": "https://github.com/purescript-node/purescript-node-event-emitter.git#^3.0.0"
   },
   "devDependencies": {
     "purescript-console": "^6.0.0"

--- a/src/Node/Net.js
+++ b/src/Node/Net.js
@@ -1,4 +1,1 @@
-import net from "net";
-export const isIP = net.isIP;
-export const isIPv4 = net.isIPv4;
-export const isIPv6 = net.isIPv6;
+export { isIP as isIPImpl, isIPv4, isIPv6 } from "net";

--- a/src/Node/Net.purs
+++ b/src/Node/Net.purs
@@ -1,12 +1,25 @@
 module Node.Net
   ( isIP
+  , isIP'
   , isIPv4
   , isIPv6
   ) where
 
+import Data.Maybe (Maybe(..))
+import Node.Net.Types (IpFamily(..))
+
+isIP :: String -> Maybe IpFamily
+isIP s = case isIP' s of
+  4 -> Just IPv4
+  6 -> Just IPv6
+  _ -> Nothing
+
 -- | Returns `4` if the `String` is a valid IPv4 address, `6` if the `String`
 -- | is a valid IPv6 address, and `0` otherwise.
-foreign import isIP :: String -> Int
+isIP' :: String -> Int
+isIP' = isIPImpl
+
+foreign import isIPImpl :: String -> Int
 
 -- | Returns `true` if the `String` is a valid IPv4 address,
 -- | and `false` otherwise.

--- a/src/Node/Net/BlockList.js
+++ b/src/Node/Net/BlockList.js
@@ -1,0 +1,5 @@
+export const addAddressImpl = (bl, addr, ty) => bl.addAddress(addr, ty);
+export const addRangeImpl = (bl, start, end, ty) => bl.addRange(start, end, ty);
+export const addSubnetImpl = (bl, net, prefix, ty) => bl.addSubnet(net, prefix, ty);
+export const checkImpl = (bl, addr, ty) => bl.check(addr, ty);
+export const rulesImpl = (bl) => bl.rules;

--- a/src/Node/Net/BlockList.purs
+++ b/src/Node/Net/BlockList.purs
@@ -1,0 +1,62 @@
+module Node.Net.BlockList
+  ( addAddressAddr
+  , addAddressStr
+  , addRangeStrStr
+  , addRangeStrAddr
+  , addRangeAddrStr
+  , addRangeAddrAddr
+  , addSubnetStr
+  , addSubnetAddr
+  , checkStr
+  , checkAddr
+  , rules
+  ) where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, EffectFn3, EffectFn4, runEffectFn1, runEffectFn3, runEffectFn4)
+import Node.Net.Types (BlockList, IpFamily, SocketAddress, toNodeIpFamily)
+
+foreign import addAddressImpl :: forall a. EffectFn3 (BlockList) a (String) (Unit)
+
+addAddressAddr :: forall ipFamily. BlockList -> SocketAddress ipFamily -> IpFamily -> Effect Unit
+addAddressAddr bl a ty = runEffectFn3 addAddressImpl bl a (toNodeIpFamily ty)
+
+addAddressStr :: BlockList -> String -> IpFamily -> Effect Unit
+addAddressStr bl a ty = runEffectFn3 addAddressImpl bl a (toNodeIpFamily ty)
+
+foreign import addRangeImpl :: forall a b. EffectFn4 (BlockList) a b (IpFamily) (Unit)
+
+addRangeStrStr :: BlockList -> String -> String -> IpFamily -> Effect Unit
+addRangeStrStr bl start end ty = runEffectFn4 addRangeImpl bl start end ty
+
+addRangeStrAddr :: forall ipFamily. BlockList -> String -> SocketAddress ipFamily -> IpFamily -> Effect Unit
+addRangeStrAddr bl start end ty = runEffectFn4 addRangeImpl bl start end ty
+
+addRangeAddrStr :: forall ipFamily. BlockList -> String -> SocketAddress ipFamily -> IpFamily -> Effect Unit
+addRangeAddrStr bl start end ty = runEffectFn4 addRangeImpl bl start end ty
+
+addRangeAddrAddr :: forall ipFamilyStart ipFamilyEnd. BlockList -> SocketAddress ipFamilyStart -> SocketAddress ipFamilyEnd -> IpFamily -> Effect Unit
+addRangeAddrAddr bl start end ty = runEffectFn4 addRangeImpl bl start end ty
+
+foreign import addSubnetImpl :: forall a. EffectFn4 (BlockList) a (Int) (IpFamily) (Unit)
+
+addSubnetStr :: BlockList -> String -> Int -> IpFamily -> Effect Unit
+addSubnetStr bl net prefix ty = runEffectFn4 addSubnetImpl bl net prefix ty
+
+addSubnetAddr :: forall ipFamily. BlockList -> SocketAddress ipFamily -> Int -> IpFamily -> Effect Unit
+addSubnetAddr bl net prefix ty = runEffectFn4 addSubnetImpl bl net prefix ty
+
+foreign import checkImpl :: forall a. EffectFn3 (BlockList) a (IpFamily) (Boolean)
+
+checkStr :: BlockList -> String -> IpFamily -> Effect Boolean
+checkStr bl addresss ty = runEffectFn3 checkImpl bl addresss ty
+
+checkAddr :: forall ipFamily. BlockList -> SocketAddress ipFamily -> IpFamily -> Effect Boolean
+checkAddr bl addresss ty = runEffectFn3 checkImpl bl addresss ty
+
+rules :: BlockList -> Effect (Array String)
+rules bl = runEffectFn1 rulesImpl bl
+
+foreign import rulesImpl :: EffectFn1 (BlockList) ((Array String))

--- a/src/Node/Net/Server.js
+++ b/src/Node/Net/Server.js
@@ -1,27 +1,14 @@
-import net from "net";
+import net from "node:net";
 
-export function addressImpl(server) {
-  return server.address();
-}
+export const newServerImpl = () => new net.Server();
+export const newServerOptionsImpl = (o) => new net.Server(o);
 
-export function closeImpl(server, callback) {
-  server.close(callback);
-}
-
-export const createServerImpl = net.createServer;
-
-export function getConnectionsImpl(server, callback) {
-  server.getConnections(callback);
-}
-
-export function listenImpl(server, options, callback) {
-  server.listen(options, callback);
-}
-
-export function listeningImpl(socket) {
-  return socket.listening;
-}
-
-export function onImpl(event, server, callback) {
-  server.on(event, callback);
-}
+export const addressTcpImpl = (s) => s.address();
+export const addressIpcImpl = (s) => s.address();
+export const closeImpl = (s) => s.close();
+export const getConnectionsImpl = (s, cb) => s.getConnections(cb);
+export const listenImpl = (s, o) => s.listen(o);
+export const listeningImpl = (s) => s.listening;
+export const maxConnectionsImpl = (s) => s.maxConnections;
+export const refImpl = (s) => s.ref();
+export const unrefImpl = (s) => s.unref();

--- a/src/Node/Net/Server.purs
+++ b/src/Node/Net/Server.purs
@@ -42,11 +42,11 @@ import Foreign (F, Foreign, readInt, readString)
 import Foreign.Index (readProp)
 import Node.Net.Socket (Socket)
 
-type Address
-  = { address :: String
-    , family :: String
-    , port :: Int
-    }
+type Address =
+  { address :: String
+  , family :: String
+  , port :: Int
+  }
 
 -- | Options to configure the listening side of a `Server`.
 -- | These options decide whether the `Server` is ICP or TCP.
@@ -76,10 +76,12 @@ address server = do
   where
   hush :: F ~> Maybe
   hush f = either (\_ -> Nothing) Just (runExcept f)
+
   read :: Foreign -> Maybe (Either Address String)
   read value =
     hush (map Left $ readAddress value)
       <|> hush (map Right $ readString value)
+
   readAddress :: Foreign -> F Address
   readAddress value = ado
     address <- readProp "address" value >>= readString

--- a/src/Node/Net/Server.purs
+++ b/src/Node/Net/Server.purs
@@ -1,249 +1,175 @@
 module Node.Net.Server
-  ( Address
-  , ListenOptions
-  , Server
-  , ServerOptions
-  , address
+  ( toEventEmitter
+  , createTcpServer
+  , createTcpServer'
+  , createIpcServer
+  , createIpcServer'
+  , closeH
+  , connectionH
+  , errorH
+  , listeningH
+  , dropHandleTcp
+  , dropHandleIpc
+  , addressTcp
+  , addressIpc
   , close
-  , createServer
   , getConnections
-  , listen
-  , listenBacklog
-  , listenExclusive
-  , listenHost
-  , listenICP
-  , listenIpv6Only
-  , listenPath
-  , listenPort
-  , listenReadableAll
-  , listenTCP
-  , listenWritableAll
+  , listenTcp
+  , listenIpc
   , listening
-  , onClose
-  , onConnection
-  , onError
-  , onListening
-  , serverAllowHalfOpen
-  , serverPauseOnConnect
+  , maxConnections
+  , ref
+  , unref
   ) where
 
 import Prelude
 
-import Control.Alt ((<|>))
-import Control.Monad.Except (runExcept)
-import Data.Either (Either(..), either)
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
-import Data.Options (Option, Options, opt, options, (:=))
 import Effect (Effect)
 import Effect.Exception (Error)
-import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3, mkEffectFn1, mkEffectFn2, runEffectFn1, runEffectFn2, runEffectFn3)
-import Foreign (F, Foreign, readInt, readString)
-import Foreign.Index (readProp)
-import Node.Net.Socket (Socket)
+import Effect.Uncurried (EffectFn1, EffectFn2, mkEffectFn1, mkEffectFn2, runEffectFn1, runEffectFn2)
+import Node.EventEmitter (EventEmitter, EventHandle(..))
+import Node.EventEmitter.UtilTypes (EventHandle1, EventHandle0)
+import Node.Net.Types (IPC, IpFamily, ListenIpcOptions, ListenTcpOptions, NewServerOptions, Server, Socket, TCP, unsafeFromNodeIpFamily)
+import Prim.Row as Row
+import Unsafe.Coerce (unsafeCoerce)
 
-type Address =
-  { address :: String
-  , family :: String
-  , port :: Int
-  }
+toEventEmitter :: forall connectionType. Server connectionType -> EventEmitter
+toEventEmitter = unsafeCoerce
 
--- | Options to configure the listening side of a `Server`.
--- | These options decide whether the `Server` is ICP or TCP.
--- |
--- | One of `path` or `port` must be set.
--- | Setting `path` will make the `Server` ICP.
--- | Setting `port` will make the `Server` TCP.
-data ListenOptions
+createTcpServer :: Effect (Server TCP)
+createTcpServer = newServerImpl
 
--- | An ICP or TCP server.
-foreign import data Server :: Type
+createIpcServer :: Effect (Server IPC)
+createIpcServer = newServerImpl
 
--- | Options to configure the basics of a `Server`.
-data ServerOptions
+foreign import newServerImpl :: forall connectionType. Effect (Server connectionType)
 
-foreign import addressImpl :: EffectFn1 Server (Nullable Foreign)
+createTcpServer'
+  :: forall r trash
+   . Row.Union r trash (NewServerOptions ())
+  => { | r }
+  -> Effect (Server TCP)
+createTcpServer' o = runEffectFn1 newServerOptionsImpl o
 
--- | Attempts to return the bound address of a `Server`.
--- |
--- | If the `Server` is not listening, `Nothing` is returned.
--- | If the `Server` is ICP, it will return a `String`.
--- | If the `Server` is TCP, it will return an `Address`.
-address :: Server -> Effect (Maybe (Either Address String))
-address server = do
-  x <- runEffectFn1 addressImpl server
-  pure (toMaybe x >>= read)
-  where
-  hush :: F ~> Maybe
-  hush f = either (\_ -> Nothing) Just (runExcept f)
+createIpcServer'
+  :: forall r trash
+   . Row.Union r trash (NewServerOptions ())
+  => { | r }
+  -> Effect (Server IPC)
+createIpcServer' o = runEffectFn1 newServerOptionsImpl o
 
-  read :: Foreign -> Maybe (Either Address String)
-  read value =
-    hush (map Left $ readAddress value)
-      <|> hush (map Right $ readString value)
+foreign import newServerOptionsImpl :: forall r connectionType. EffectFn1 ({ | r }) (Server connectionType)
 
-  readAddress :: Foreign -> F Address
-  readAddress value = ado
-    address <- readProp "address" value >>= readString
-    family <- readProp "family" value >>= readString
-    port <- readProp "port" value >>= readInt
-    in { address, family, port }
+closeH :: forall connectionType. EventHandle0 (Server connectionType)
+closeH = EventHandle "close" identity
 
-foreign import closeImpl :: EffectFn2 Server (EffectFn1 (Nullable Error) Unit) Unit
+connectionH :: forall connectionType. EventHandle1 (Server connectionType) (Socket connectionType)
+connectionH = EventHandle "connection" mkEffectFn1
 
--- | Closes the `Server` and invokes the callback after the `'close'` event
--- | is emitted.
--- | An `Error` is passed to the callback if the `Server` was not open.
-close :: Server -> (Maybe Error -> Effect Unit) -> Effect Unit
-close server callback =
-  runEffectFn2 closeImpl server (mkEffectFn1 \err -> callback $ toMaybe err)
+errorH :: forall connectionType. EventHandle1 (Server connectionType) Error
+errorH = EventHandle "error" mkEffectFn1
 
-foreign import createServerImpl :: EffectFn2 Foreign (EffectFn1 Socket Unit) Server
+listeningH :: forall connectionType. EventHandle0 (Server connectionType)
+listeningH = EventHandle "listening" identity
 
--- | Creates an ICP or TCP `Server`, returns the `Server`,
--- | and adds the callback as a listenter for the `'connection'` event.
--- | the `Server` will be ICP or TCP depending on what it `listen`s to.
-createServer :: Options ServerOptions -> (Socket -> Effect Unit) -> Effect Server
-createServer opts callback =
-  runEffectFn2
-    createServerImpl
-    (options opts)
-    (mkEffectFn1 \socket -> callback socket)
+dropHandleTcp
+  :: EventHandle (Server TCP)
+       ( { localAddress :: String
+         , localPort :: Int
+         , localFamily :: IpFamily
+         , remoteAddress :: String
+         , remotePort :: Int
+         , remoteFamily :: IpFamily
+         }
+         -> Effect Unit
+       )
+       ( EffectFn1
+           { localAddress :: String
+           , localPort :: Int
+           , localFamily :: String
+           , remoteAddress :: String
+           , remotePort :: Int
+           , remoteFamily :: String
+           }
+           Unit
+       )
+dropHandleTcp = EventHandle "drop" \cb -> mkEffectFn1 \r ->
+  cb
+    { localAddress: r.localAddress
+    , localPort: r.localPort
+    , localFamily: unsafeFromNodeIpFamily r.localFamily
+    , remoteAddress: r.remoteAddress
+    , remotePort: r.remotePort
+    , remoteFamily: unsafeFromNodeIpFamily r.remoteFamily
+    }
 
-foreign import getConnectionsImpl :: EffectFn2 Server (EffectFn2 (Nullable Error) (Nullable Int) Unit) Unit
+dropHandleIpc :: EventHandle0 (Server IPC)
+dropHandleIpc = EventHandle "drop" identity
 
--- | Returns the number of concurrent connections to the `Server`.
-getConnections :: Server -> (Either Error Int -> Effect Unit) -> Effect Unit
-getConnections server callback =
-  runEffectFn2 getConnectionsImpl server $ mkEffectFn2 \err' count' ->
-    case toMaybe err', toMaybe count' of
-      Just err, _ -> callback (Left err)
-      _, Just count -> callback (Right count)
-      _, _ -> mempty
+addressTcp :: Server TCP -> Effect (Maybe { port :: Int, family :: IpFamily, address :: String })
+addressTcp s = (runEffectFn1 addressTcpImpl s) <#>
+  ( \o ->
+      (toMaybe o) <#> \r ->
+        { port: r.port
+        , family: unsafeFromNodeIpFamily r.family
+        , address: r.address
+        }
+  )
 
-foreign import listenImpl :: EffectFn3 Server Foreign (Effect Unit) Unit
+foreign import addressTcpImpl :: EffectFn1 (Server TCP) (Nullable { port :: Int, family :: String, address :: String })
 
--- | Starts the `Server` as an ICP or TCP `Server` listening for connections,
--- | adds the callback as a listener to the `'listening'` event, and emits the
--- | `'listening'` event.
-listen :: Server -> Options ListenOptions -> Effect Unit -> Effect Unit
-listen server opts callback =
-  runEffectFn3 listenImpl server (options opts) callback
+addressIpc :: Server IPC -> Effect (Maybe String)
+addressIpc s = map toMaybe $ runEffectFn1 addressIpcImpl s
 
--- | Maximum number of pending connections.
--- | Defaults to `511`.
-listenBacklog :: Option ListenOptions Int
-listenBacklog = opt "backlog"
+foreign import addressIpcImpl :: EffectFn1 (Server IPC) (Nullable String)
 
--- | When `true`, the handle cannot be shared and will result in an error.
--- | When `false`, the handle can be shared.
--- | Defaults to `false`.
-listenExclusive :: Option ListenOptions Boolean
-listenExclusive = opt "exclusive"
+close :: forall connectionType. Server connectionType -> Effect Unit
+close s = runEffectFn1 closeImpl s
 
--- | The host to configure TCP `Server`s.
--- |
--- | Determines the host the `Server` will attempt to listen on.
--- | Defaults to IPv6 `::` if available, and IPv4 `0.0.0.0` otherwise.
-listenHost :: Option ListenOptions String
-listenHost = opt "host"
+foreign import closeImpl :: forall connectionType. EffectFn1 (Server connectionType) (Unit)
 
--- | Starts the `Server` as an ICP `Server` listening for connections,
--- | adds the callback as a listener to the `'listening'` event, and emits the
--- | `'listening'` event.
-listenICP :: Server -> String -> Int -> Effect Unit -> Effect Unit
-listenICP server path backlog callback =
-  runEffectFn3
-    listenImpl
-    server
-    (options $ listenBacklog := backlog <> listenPath := path)
-    callback
+getConnections :: forall connectionType. Server connectionType -> (Error -> Int -> Effect Unit) -> Effect Unit
+getConnections s cb = runEffectFn2 getConnectionsImpl s $ mkEffectFn2 cb
 
--- | When `true`, only binds to IPv6 hosts and not also to IPv4 hosts.
--- | Defaults to `false`.
-listenIpv6Only :: Option ListenOptions Boolean
-listenIpv6Only = opt "ipv6Only"
+foreign import getConnectionsImpl :: forall connectionType. EffectFn2 (Server connectionType) (EffectFn2 Error Int Unit) (Unit)
 
--- | The path to configure ICP `Server`s.
--- |
--- | Determines the ICP endpoint the `Server` will attempt to listen on.
-listenPath :: Option ListenOptions String
-listenPath = opt "path"
+listenTcp
+  :: forall r trash
+   . Row.Union r trash (ListenTcpOptions ())
+  => Server TCP
+  -> { | r }
+  -> Effect Unit
+listenTcp s o = runEffectFn2 listenImpl s o
 
--- | The port to configure TCP `Server`s.
--- |
--- | Determines the TCP endpoint the `Server` will attempt to listen on.
--- | When `0`, the OS will assign an arbitrary port.
-listenPort :: Option ListenOptions Int
-listenPort = opt "port"
+listenIpc
+  :: forall r trash
+   . Row.Union r trash (ListenIpcOptions ())
+  => (Server IPC)
+  -> { | r }
+  -> Effect Unit
+listenIpc s o = runEffectFn2 listenImpl s o
 
--- | Makes the ICP pipe readable for all users.
--- | Defaults to `false`.
-listenReadableAll :: Option ListenOptions Boolean
-listenReadableAll = opt "readableAll"
+foreign import listenImpl :: forall r connectionType. EffectFn2 (Server connectionType) ({ | r }) (Unit)
 
--- | Starts the `Server` as a TCP `Server` listening for connections,
--- | adds the callback as a listener to the `'listening'` event, and emits the
--- | `'listening'` event.
-listenTCP :: Server -> Int -> String -> Int -> Effect Unit -> Effect Unit
-listenTCP server port host backlog callback =
-  runEffectFn3
-    listenImpl
-    server
-    (options $ listenBacklog := backlog <> listenHost := host <> listenPort := port)
-    callback
+listening :: forall connectionType. Server connectionType -> Effect Boolean
+listening s = runEffectFn1 listeningImpl s
 
--- | Makes the ICP pipe writable for all users.
--- | Defaults to `false`.
-listenWritableAll :: Option ListenOptions Boolean
-listenWritableAll = opt "writableAll"
+foreign import listeningImpl :: forall connectionType. EffectFn1 (Server connectionType) (Boolean)
 
-foreign import listeningImpl :: EffectFn1 Server Boolean
+maxConnections :: forall connectionType. Server connectionType -> Effect Int
+maxConnections s = runEffectFn1 maxConnectionsImpl s
 
--- | Returns `true` if the `Server` is listening for connections, and `false`
--- | otherwise.
-listening :: Server -> Effect Boolean
-listening server = runEffectFn1 listeningImpl server
+foreign import maxConnectionsImpl :: forall connectionType. EffectFn1 (Server connectionType) (Int)
 
--- | Attaches the callback as a listener to the `'close'` event.
--- |
--- | `'close'` is emitted when a close occurs.
--- | Will not be emitted until all connections have ended.
-onClose :: Server -> Effect Unit -> Effect Unit
-onClose server callback = runEffectFn3 onImpl "close" server callback
+ref :: forall connectionType. Server connectionType -> Effect Unit
+ref s = runEffectFn1 refImpl s
 
--- | Attaches the callback as a listener to the `'connection'` event.
--- |
--- | `'connection'` is emitted when a new connection is made.
-onConnection :: Server -> (Socket -> Effect Unit) -> Effect Unit
-onConnection server callback =
-  runEffectFn3
-    onImpl
-    "connection"
-    server
-    (mkEffectFn1 \socket -> callback socket)
+foreign import refImpl :: forall connectionType. EffectFn1 (Server connectionType) (Unit)
 
--- | Attaches the callback as a listener to the `'error'` event.
--- |
--- | `'error'` is emitted when an error occurs.
-onError :: Server -> (Error -> Effect Unit) -> Effect Unit
-onError server callback =
-  runEffectFn3 onImpl "error" server (mkEffectFn1 \error -> callback error)
+unref :: forall connectionType. Server connectionType -> Effect Unit
+unref s = runEffectFn1 unrefImpl s
 
--- | Attaches the callback as a listener to the `'listening'` event.
--- |
--- | `'listening'` is emitted when the `Server` has been bound.
-onListening :: Server -> Effect Unit -> Effect Unit
-onListening server callback = runEffectFn3 onImpl "listening" server callback
+foreign import unrefImpl :: forall connectionType. EffectFn1 (Server connectionType) (Unit)
 
-foreign import onImpl :: forall f. EffectFn3 String Server (f Unit) Unit
-
--- | Allows half open TCP connections.
--- | Defaults to `false`.
-serverAllowHalfOpen :: Option ServerOptions Boolean
-serverAllowHalfOpen = opt "allowHalfOpen"
-
--- | When `true`, pauses the `Socket` on incomming connections.
--- | Defaults to `false`.
-serverPauseOnConnect :: Option ServerOptions Boolean
-serverPauseOnConnect = opt "pauseOnConnect"

--- a/src/Node/Net/Socket.js
+++ b/src/Node/Net/Socket.js
@@ -1,109 +1,30 @@
-import net from "net";
+import net from "node:net";
+export const newImpl = (o) => new net.Socket(o);
+export const addressImpl = (s) => s.address();
+export const bytesReadImpl = (s) => s.bytesRead;
+export const bytesWrittenImpl = (s) => s.bytesWritten;
+export const createConnectionImpl = (o) => net.createConnection(o);
+export const connectTcpImpl = (s, o) => s.connect(o);
+export const connectIpcImpl = (s, p) => s.connect(p);
+export const connectingImpl = (s) => s.connecting;
+export const destroySoonImpl = (s) => s.destroySoon();
+export const localAddressImpl = (s) => s.localAddress;
+export const localPortImpl = (s) => s.localPort;
+export const localFamilyImpl = (s) => s.localFamily;
+export const pendingImpl = (s) => s.pending;
+export const refImpl = (s) => s.ref();
+export const remoteAddressImpl = (s) => s.remoteAddress;
+export const remotePortImpl = (s) => s.remotePort;
+export const remoteFamilyImpl = (s) => s.remoteFamily;
+export const resetAndDestroyImpl = (s) => s.resetAndDestroy();
+export const setKeepAliveImpl = (s) => s.setKeepAlive();
+export const setKeepAliveBooleanImpl = (s, b) => s.setKeepAlive(b);
+export const setKeepAliveInitialDelayImpl = (s, d) => s.setKeepAlive(d);
+export const setKeepAliveAllImpl = (s, b, d) => s.setKeepAlive(b, d);
+export const setNoDelayImpl = (s) => s.setNoDelay();
+export const setNoDelayBooleanImpl = (s, b) => s.setNoDelay(b);
+export const setTimeoutImpl = (s, msecs) => s.setTimeout(msecs);
+export const timeoutImpl = (s) => s.timeout;
+export const unrefImpl = (s) => s.unRef();
+export const readyStateImpl = (s) => s.readyState;
 
-export function bufferSizeImpl(socket) {
-  return socket.bufferSize;
-}
-
-export function bytesReadImpl(socket) {
-  return socket.bytesRead;
-}
-
-export function bytesWrittenImpl(socket) {
-  return socket.bytesWritten;
-}
-
-export function connectImpl(socket, options, callback) {
-  socket.connect(options, callback);
-}
-
-export function connectingImpl(socket) {
-  return socket.connecting;
-}
-
-export const createConnectionImpl = net.createConnection;
-
-export function destroyImpl(socket, err) {
-  socket.destroy(err);
-}
-
-export function destroyedImpl(socket) {
-  return socket.destroyed;
-}
-
-export function endImpl(socket, buffer, callback) {
-  socket.end(buffer, null, callback);
-}
-
-export function endStringImpl(socket, str, encoding, callback) {
-  socket.end(str, encoding, callback);
-}
-
-export function localAddressImpl(socket) {
-  return socket.localAddress;
-}
-
-export function localPortImpl(socket) {
-  return socket.localPort;
-}
-
-export function onDataImpl(socket, callbackBuffer, callbackString) {
-  socket.on("data", function (data) {
-    if (typeof data === "string") {
-      callbackString(data);
-    } else {
-      callbackBuffer(data);
-    }
-  });
-}
-
-export function onImpl(event, socket, callback) {
-  socket.on(event, callback);
-}
-
-export function pauseImpl(socket) {
-  socket.pause();
-}
-
-export function pendingImpl(socket) {
-  return socket.pending;
-}
-
-export function remoteAddressImpl(socket) {
-  return socket.remoteAddress;
-}
-
-export function remoteFamilyImpl(socket) {
-  return socket.remoteFamily;
-}
-
-export function remotePortImpl(socket) {
-  return socket.remotePort;
-}
-
-export function resumeImpl(socket) {
-  socket.resume();
-}
-
-export function setEncodingImpl(socket, encoding) {
-  socket.setEncoding(encoding);
-}
-
-export function setKeepAliveImpl(socket, enable, initialDelay) {
-  socket.setKeepAlive(enable, initialDelay);
-}
-
-export function setNoDelayImpl(socket, noDelay) {
-  socket.setNoDelay(noDelay);
-}
-
-export function setTimeoutImpl(socket, timeout, callback) {
-  socket.setTimeout(timeout, callback);
-}
-
-export function writeImpl(socket, buffer, callback) {
-  return socket.write(buffer, null, callback);
-}
-
-export function writeStringImpl(socket, str, encoding, callback) {
-  return socket.write(str, encoding, callback);
-}

--- a/src/Node/Net/Socket.purs
+++ b/src/Node/Net/Socket.purs
@@ -79,11 +79,11 @@ import Node.FS (FileDescriptor)
 -- | Setting `port` will make the `Socket` TCP.
 data ConnectOptions
 
-type Lookup
-  = { address :: String
-    , family :: Maybe Int
-    , host :: String
-    }
+type Lookup =
+  { address :: String
+  , family :: Maybe Int
+  , host :: String
+  }
 
 -- | An ICP endpoint or TCP socket.
 foreign import data Socket :: Type

--- a/src/Node/Net/Socket.purs
+++ b/src/Node/Net/Socket.purs
@@ -1,481 +1,263 @@
 module Node.Net.Socket
-  ( ConnectOptions
-  , Lookup
-  , Socket
-  , SocketOptions
-  , bufferSize
+  ( newTcp
+  , newIpc
+  , toDuplex
+  , toEventEmitter
+  , closeH
+  , connectH
+  , lookupH
+  , readyH
+  , timeoutH
+  , address
   , bytesRead
   , bytesWritten
-  , connect
-  , connectFamily
-  , connectHints
-  , connectHost
-  , connectICP
-  , connectLocalAddress
-  , connectLocalPort
-  , connectPath
-  , connectPort
-  , connectTCP
-  , connecting
-  , createConnection
-  , createConnectionICP
   , createConnectionTCP
-  , destroy
-  , destroyed
-  , end
-  , endString
+  , createConnectionIpc
+  , connectTcp
+  , connectIpc
+  , connecting
+  , destroySoon
   , localAddress
   , localPort
-  , onClose
-  , onConnect
-  , onData
-  , onDrain
-  , onEnd
-  , onError
-  , onLookup
-  , onReady
-  , onTimeout
-  , pause
+  , localFamily
   , pending
+  , ref
   , remoteAddress
-  , remoteFamily
   , remotePort
-  , resume
-  , setEncoding
+  , remoteFamily
+  , resetAndDestroy
   , setKeepAlive
+  , setKeepAliveBoolean
+  , setKeepAliveInitialDelay
+  , setKeepAliveAll
   , setNoDelay
+  , setNoDelay'
   , setTimeout
-  , socketAllowHalfOpen
-  , socketFd
-  , socketHost
-  , socketPath
-  , socketPort
-  , socketReadable
-  , socketTimeout
-  , socketWritable
-  , write
-  , writeString
+  , clearTimeout
+  , timeout
+  , unref
+  , readyState
   ) where
 
 import Prelude
 
-import Data.Either (Either(..))
-import Data.Maybe (Maybe(..))
-import Data.Nullable (Nullable, toMaybe, toNullable)
-import Data.Options (Option, Options, opt, options, (:=))
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Data.Time.Duration (Milliseconds(..))
 import Effect (Effect)
 import Effect.Exception (Error)
-import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3, EffectFn4, mkEffectFn1, mkEffectFn4, runEffectFn1, runEffectFn2, runEffectFn3, runEffectFn4)
-import Foreign (Foreign)
-import Node.Buffer (Buffer)
-import Node.Encoding (Encoding, encodingToNode)
-import Node.FS (FileDescriptor)
-
--- | Options to configure the connecting side of a `Socket`.
--- | These options decide whether the `Socket` is ICP or TCP.
--- |
--- | One of `path` or `port` must be set.
--- | Setting `path` will make the `Socket` ICP.
--- | Setting `port` will make the `Socket` TCP.
-data ConnectOptions
-
-type Lookup =
-  { address :: String
-  , family :: Maybe Int
-  , host :: String
-  }
-
--- | An ICP endpoint or TCP socket.
-foreign import data Socket :: Type
-
--- | Options to configure the basics of a `Socket`.
-data SocketOptions
-
-foreign import bufferSizeImpl :: EffectFn1 Socket (Nullable Int)
-
--- | The number of characters buffered to be written on a `Socket`.
--- |
--- | N.B. The number of characters is not equal to the number of bytes.
-bufferSize :: Socket -> Effect (Maybe Int)
-bufferSize socket = do
-  size <- runEffectFn1 bufferSizeImpl socket
-  pure (toMaybe size)
-
-foreign import bytesReadImpl :: EffectFn1 Socket Int
-
--- | The number of bytes recieved on the `Socket`.
-bytesRead :: Socket -> Effect Int
-bytesRead socket = runEffectFn1 bytesReadImpl socket
-
-foreign import bytesWrittenImpl :: EffectFn1 Socket Int
-
--- | The number of bytes sent on the `Socket`.
-bytesWritten :: Socket -> Effect Int
-bytesWritten socket = runEffectFn1 bytesWrittenImpl socket
-
-foreign import connectImpl :: EffectFn3 Socket Foreign (Effect Unit) Unit
-
--- | Creates a custom ICP or TCP connection on the `Socket`.
--- | Normally, `createConnection` should be used to create the socket.
-connect :: Socket -> Options ConnectOptions -> Effect Unit -> Effect Unit
-connect socket opts callback =
-  runEffectFn3 connectImpl socket (options opts) callback
-
--- | Version of IP stack, either `4` or `6`.
--- | Defaults to `4`.
-connectFamily :: Option ConnectOptions Int
-connectFamily = opt "family"
-
--- | DNS lookup hints.
-connectHints :: Option ConnectOptions Int
-connectHints = opt "hints"
-
--- | The host to configure TCP `Socket`s.
--- |
--- | Determines the host the `Socket` will attempt to connect to.
--- | Defaults to `localhost`.
-connectHost :: Option ConnectOptions String
-connectHost = opt "host"
-
--- | Creates a custom ICP connection on the `Socket`.
--- | Normally, `createConnectionICP` should be used to create the socket.
-connectICP :: Socket -> String -> Effect Unit -> Effect Unit
-connectICP socket path callback =
-  runEffectFn3 connectImpl socket (options $ connectPath := path) callback
-
--- | Address the `Socket` should connect from.
-connectLocalAddress :: Option ConnectOptions String
-connectLocalAddress = opt "localAddress"
-
--- | Port the `Socket` should connect from.
-connectLocalPort :: Option ConnectOptions Int
-connectLocalPort = opt "localPort"
-
--- | The path to configure ICP `Socket`s.
--- |
--- | Determines the ICP endpoint the `Socket` will attempt to connect to.
-connectPath :: Option ConnectOptions String
-connectPath = opt "path"
-
--- | The port to configure TCP `Server`s.
--- |
--- | Determines the TCP endpoint the `Server` will attempt to listen on.
-connectPort :: Option ConnectOptions Int
-connectPort = opt "port"
-
--- | Creates a custom TCP connection on the `Socket`.
--- | Normally, `createConnectionTCP` should be used to create the socket.
-connectTCP :: Socket -> Int -> String -> Effect Unit -> Effect Unit
-connectTCP socket port host callback =
-  runEffectFn3
-    connectImpl
-    socket
-    (options $ connectHost := host <> connectPort := port)
-    callback
-
-foreign import connectingImpl :: EffectFn1 Socket Boolean
-
--- | Returns `true` if `connect` was called, but the `'connect'` event hasn't
--- | been emitted yet.
--- | Returns `false` any other time.
-connecting :: Socket -> Effect Boolean
-connecting socket = runEffectFn1 connectingImpl socket
-
-foreign import createConnectionImpl :: EffectFn2 Foreign (Effect Unit) Socket
-
--- | Creates an ICP or TCP `Socket`, initiates a connection,
--- | returns the `Socket`, adds the callback as a one-time listener for the
--- | `'connect'` event, and emits the `'connect'` event.
-createConnection :: Options SocketOptions -> Effect Unit -> Effect Socket
-createConnection opts callback =
-  runEffectFn2 createConnectionImpl (options opts) callback
-
--- | Creates an ICP `Socket`, initiates a connection,
--- | returns the `Socket`, adds the callback as a one-time listener for the
--- | `'connect'` event, and emits the `'connect'` event.
-createConnectionICP :: String -> Effect Unit -> Effect Socket
-createConnectionICP path callback =
-  runEffectFn2 createConnectionImpl (options $ socketPath := path) callback
-
--- | Creates a TCP `Socket`, initiates a connection,
--- | returns the `Socket`, adds the callback as a one-time listener for the
--- | `'connect'` event, and emits the `'connect'` event.
-createConnectionTCP :: Int -> String -> Effect Unit -> Effect Socket
-createConnectionTCP port host callback =
-  runEffectFn2
-    createConnectionImpl
-    (options $ socketHost := host <> socketPort := port)
-    callback
-
-foreign import destroyImpl :: EffectFn2 Socket (Nullable Error) Unit
-
--- | Ensure no more I/O activity happens on the socket.
--- |
--- | If an `Error` is provided, an `'error'` event is emitted.
-destroy :: Socket -> Maybe Error -> Effect Unit
-destroy socket err = runEffectFn2 destroyImpl socket (toNullable err)
-
-foreign import destroyedImpl :: EffectFn1 Socket Boolean
-
--- | Returns `true` if the connection is destroyed and can no longer transfer
--- | data.
-destroyed :: Socket -> Effect Boolean
-destroyed socket = runEffectFn1 destroyedImpl socket
-
-foreign import endImpl :: EffectFn3 Socket Buffer (Effect Unit) Unit
-
--- | Send a `FIN` packet to half-close the `Socket`.
--- | The server might still send more data.
--- | Invokes the callback after the `Socket` is finished.
-end :: Socket -> Buffer -> Effect Unit -> Effect Unit
-end socket buffer callback = runEffectFn3 endImpl socket buffer callback
-
-foreign import endStringImpl :: EffectFn4 Socket String String (Effect Unit) Unit
-
--- | Send a `FIN` packet to half-close the `Socket`.
--- | The server might still send more data.
--- | Invokes the callback after the `Socket` is finished.
-endString :: Socket -> String -> Encoding -> Effect Unit -> Effect Unit
-endString socket str encoding callback =
-  runEffectFn4 endStringImpl socket str (encodingToNode encoding) callback
-
-foreign import localAddressImpl :: EffectFn1 Socket (Nullable String)
-
--- | Attempts to return the address a client is connecting on.
--- | E.g. if a client connects from `192.168.1.1`,
--- | the result would be `Just "192.168.1.1"`.
-localAddress :: Socket -> Effect (Maybe String)
-localAddress socket = do
-  address' <- runEffectFn1 localAddressImpl socket
-  pure (toMaybe address')
-
-foreign import localPortImpl :: EffectFn1 Socket (Nullable Int)
-
--- | Attempts to return the port a client is connecting on.
--- | E.g. if a client connects from `80`,
--- | the result would be `Just 80`.
-localPort :: Socket -> Effect (Maybe Int)
-localPort socket = do
-  port <- runEffectFn1 localPortImpl socket
-  pure (toMaybe port)
-
--- | Attaches the callback as a listener to the `'close'` event.
--- | The `Boolean` represents whether an error happened during transmission.
--- |
--- | `'close'` is emitted when an close occurs.
-onClose :: Socket -> (Boolean -> Effect Unit) -> Effect Unit
-onClose socket callback =
-  runEffectFn3
-    onImpl
-    "close"
-    socket
-    (mkEffectFn1 \hadError -> callback hadError)
-
--- | Attaches the callback as a listener to the `'connect'` event.
--- |
--- | `'connect'` is emitted when a new connection is successfully establed.
-onConnect :: Socket -> Effect Unit -> Effect Unit
-onConnect socket callback = runEffectFn3 onImpl "connect" socket callback
-
-foreign import onDataImpl :: EffectFn3 Socket (EffectFn1 Buffer Unit) (EffectFn1 String Unit) Unit
-
--- | Attaches the callback as a listener to the `'data'` event.
--- |
--- | `'data'` is emitted when a data is recieved.
--- | Data will be lost if there is no listener when `'data'` is emitted.
-onData :: Socket -> (Either Buffer String -> Effect Unit) -> Effect Unit
-onData socket callback =
-  runEffectFn3
-    onDataImpl
-    socket
-    (mkEffectFn1 \buffer -> callback $ Left buffer)
-    (mkEffectFn1 \str -> callback $ Right str)
-
--- | Attaches the callback as a listener to the `'drain'` event.
--- |
--- | `'drain'` is emitted when the write buffer is empty.
-onDrain :: Socket -> Effect Unit -> Effect Unit
-onDrain socket callback = runEffectFn3 onImpl "drain" socket callback
-
--- | Attaches the callback as a listener to the `'end'` event.
--- |
--- | `'end'` is emitted when the other end of the `Socket` sends a `FIN` packet.
-onEnd :: Socket -> Effect Unit -> Effect Unit
-onEnd socket callback = runEffectFn3 onImpl "end" socket callback
-
--- | Attaches the callback as a listener to the `'error'` event.
--- |
--- | `'error'` is emitted when an error occurs.
--- | `'close'` is emitted directly after this event.
-onError :: Socket -> (Error -> Effect Unit) -> Effect Unit
-onError socket callback =
-  runEffectFn3 onImpl "error" socket (mkEffectFn1 \err -> callback err)
-
-foreign import onImpl :: forall f. EffectFn3 String Socket (f Unit) Unit
-
--- | Attaches the callback as a listener to the `'lookup'` event.
--- |
--- | `'lookup'` is emitted after resolving the hostname but before connecting.
-onLookup :: Socket -> (Either Error Lookup -> Effect Unit) -> Effect Unit
-onLookup socket callback =
-  runEffectFn3 onImpl "lookup" socket $ mkEffectFn4 \err' address'' family' host' ->
-    case toMaybe err', toMaybe address'', toMaybe family', toMaybe host' of
-      Just err, _, _, _ -> callback (Left err)
-      Nothing, Just address', Just family, Just host ->
-        callback (Right { address: address', family: toMaybe family, host })
-      _, _, _, _ -> mempty
-
--- | Attaches the callback as a listener to the `'ready'` event.
--- |
--- | `'ready'` is emitted when the `Socket` is ready to be used.
-onReady :: Socket -> Effect Unit -> Effect Unit
-onReady socket callback = runEffectFn3 onImpl "ready" socket callback
-
--- | Attaches the callback as a listener to the `'timeout'` event.
--- |
--- | `'timeout'` is emitted if the `Socket` times out from inactivity.
--- | The `Socket` is still open and should be manually closed.
-onTimeout :: Socket -> Effect Unit -> Effect Unit
-onTimeout socket callback = runEffectFn3 onImpl "timeout" socket callback
-
-foreign import pauseImpl :: EffectFn1 Socket Unit
-
--- | Pauses `'data'` events from being emitted.
-pause :: Socket -> Effect Unit
-pause socket = runEffectFn1 pauseImpl socket
-
-foreign import pendingImpl :: EffectFn1 Socket Boolean
-
--- | Returns `true` if the `Socket` is not connected yet.
--- | Returns `false` otherwise.
-pending :: Socket -> Effect Boolean
-pending socket = runEffectFn1 pendingImpl socket
-
-foreign import remoteAddressImpl :: EffectFn1 Socket (Nullable String)
-
--- | Attempts to return the address a `Socket` is connected to.
-remoteAddress :: Socket -> Effect (Maybe String)
-remoteAddress socket = do
-  address' <- runEffectFn1 remoteAddressImpl socket
-  pure (toMaybe address')
-
-foreign import remoteFamilyImpl :: EffectFn1 Socket (Nullable String)
-
--- | Attempts to return the IP family a `Socket` is connected to,
--- | either `"IPv4"` or `"IPv6"`.
-remoteFamily :: Socket -> Effect (Maybe String)
-remoteFamily socket = do
-  family <- runEffectFn1 remoteFamilyImpl socket
-  pure (toMaybe family)
-
-foreign import remotePortImpl :: EffectFn1 Socket (Nullable Int)
-
--- | Attempts to return the port a `Socket` is connected to.
-remotePort :: Socket -> Effect (Maybe Int)
-remotePort socket = do
-  port <- runEffectFn1 remotePortImpl socket
-  pure (toMaybe port)
-
-foreign import resumeImpl :: EffectFn1 Socket Unit
-
--- | Resumes emitting `'data'` events.
-resume :: Socket -> Effect Unit
-resume socket = runEffectFn1 resumeImpl socket
-
-foreign import setEncodingImpl :: EffectFn2 Socket String Unit
-
--- | Sets the `Encoding` for the data read on the `Socket`.
-setEncoding :: Socket -> Encoding -> Effect Unit
-setEncoding socket encoding = runEffectFn2 setEncodingImpl socket (encodingToNode encoding)
-
-foreign import setKeepAliveImpl :: EffectFn3 Socket Boolean Int Unit
-
--- | Sets keep-alive behavior.
--- | When `true`, it enables the behavior.
--- | When `false`, it disables the behavior.
--- | The `Int` is the initial delay in milliseconds before the first probe is
--- | sent to an idle `Socket`.
-setKeepAlive :: Socket -> Boolean -> Int -> Effect Unit
-setKeepAlive socket enable initialDelay =
-  runEffectFn3 setKeepAliveImpl socket enable initialDelay
-
-foreign import setNoDelayImpl :: EffectFn2 Socket Boolean Unit
-
--- | When `true`, disables the Nagle algorithm and sends data immedately.
--- | When `false`, enables the Nagle algorithm and buffers data before sending.
-setNoDelay :: Socket -> Boolean -> Effect Unit
-setNoDelay socket noDelay = runEffectFn2 setNoDelayImpl socket noDelay
-
-foreign import setTimeoutImpl :: EffectFn3 Socket Int (Effect Unit) Unit
-
--- | When `0`, disables the existing timeout.
--- | Otherwise, sets the `Socket` to timeout after the given milliseconds.
--- | Adds the callback as a listener for the `'timeout'` event.
-setTimeout :: Socket -> Int -> Effect Unit -> Effect Unit
-setTimeout socket timeout callback =
-  runEffectFn3 setTimeoutImpl socket timeout callback
-
--- | Allows half open TCP connections.
--- | Defaults to `false`.
-socketAllowHalfOpen :: Option SocketOptions Boolean
-socketAllowHalfOpen = opt "allowHalfOpen"
-
--- | Creates a `Socket` around the given `FileDescriptor`.
--- | If not specified, creates a new `Socket`.
-socketFd :: Option SocketOptions FileDescriptor
-socketFd = opt "fd"
-
--- | The host to configure TCP `Socket`s.
--- |
--- | Determines the host the `Socket` will attempt to connect to.
--- | Defaults to `localhost`.
-socketHost :: Option SocketOptions String
-socketHost = opt "host"
-
--- | The path to configure ICP `Socket`s.
--- |
--- | Determines the ICP endpoint the `Socket` will attempt to connect to.
-socketPath :: Option SocketOptions String
-socketPath = opt "path"
-
--- | The port to configure TCP `Socket`s.
--- |
--- | Determines the TCP endpoint the `Socket` will attempt to connect to.
-socketPort :: Option SocketOptions Int
-socketPort = opt "port"
-
--- | Allows reads if a `FileDescriptor` is also set.
--- | Defaults to `false`.
-socketReadable :: Option SocketOptions Boolean
-socketReadable = opt "readable"
-
--- | Passed to `setTimeout` when the `Socket` is created but before it starts
--- | the connection.
-socketTimeout :: Option SocketOptions Int
-socketTimeout = opt "timeout"
-
--- | Allows writes if a `FileDescriptor` is also set.
--- | Defaults to `false`.
-socketWritable :: Option SocketOptions Boolean
-socketWritable = opt "writable"
-
-foreign import writeImpl :: EffectFn3 Socket Buffer (Effect Unit) Boolean
-
--- | Sends data on the `Socket` and invokes the callback after the data is
--- | finally written.
--- | Returns `true` if the data was flushed successfully.
--- | Returns `false` if the data was queued.
--- | Emits a `'drain'` event after the buffer is free.
-write :: Socket -> Buffer -> Effect Unit -> Effect Boolean
-write socket buffer callback = runEffectFn3 writeImpl socket buffer callback
-
-foreign import writeStringImpl :: EffectFn4 Socket String String (Effect Unit) Boolean
-
--- | Sends data on the `Socket` and invokes the callback after the data is
--- | finally written.
--- | Returns `true` if the data was flushed successfully.
--- | Returns `false` if the data was queued.
--- | Emits a `'drain'` event after the buffer is free.
-writeString :: Socket -> String -> Encoding -> Effect Unit -> Effect Boolean
-writeString socket str encoding callback =
-  runEffectFn4 writeStringImpl socket str (encodingToNode encoding) callback
+import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3, EffectFn4, mkEffectFn1, mkEffectFn4, runEffectFn1, runEffectFn2, runEffectFn3)
+import Node.EventEmitter (EventEmitter, EventHandle(..))
+import Node.EventEmitter.UtilTypes (EventHandle0, EventHandle1)
+import Node.Net.Types (ConnectIpcOptions, ConnectTcpOptions, IPC, IpFamily, NewSocketOptions, Socket, SocketReadyState(..), TCP, unsafeFromNodeIpFamily)
+import Node.Stream (Duplex)
+import Partial.Unsafe (unsafeCrashWith)
+import Prim.Row as Row
+import Unsafe.Coerce (unsafeCoerce)
+
+foreign import newImpl :: forall r a. EffectFn1 ({ | r }) (Socket a)
+
+newTcp
+  :: forall r trash
+   . Row.Union r trash (NewSocketOptions ())
+  => { | r }
+  -> Effect (Socket TCP)
+newTcp o = runEffectFn1 newImpl o
+
+newIpc
+  :: forall r trash
+   . Row.Union r trash (NewSocketOptions ())
+  => { | r }
+  -> Effect (Socket IPC)
+newIpc o = runEffectFn1 newImpl o
+
+toDuplex :: forall connectionType. Socket connectionType -> Duplex
+toDuplex = unsafeCoerce
+
+toEventEmitter :: forall connectionType. Socket connectionType -> EventEmitter
+toEventEmitter = unsafeCoerce
+
+closeH :: forall connectionType. EventHandle1 (Socket connectionType) Boolean
+closeH = EventHandle "close" mkEffectFn1
+
+connectH :: forall connectionType. EventHandle0 (Socket connectionType)
+connectH = EventHandle "connect" identity
+
+lookupH :: forall connectionType. EventHandle (Socket connectionType) (Maybe Error -> String -> Maybe Int -> String -> Effect Unit) (EffectFn4 (Nullable Error) String (Nullable Int) String Unit)
+lookupH = EventHandle "lookup" \cb -> mkEffectFn4 \a b c d -> cb (toMaybe a) b (toMaybe c) d
+
+readyH :: forall connectionType. EventHandle0 (Socket connectionType)
+readyH = EventHandle "ready" identity
+
+timeoutH :: forall connectionType. EventHandle0 (Socket connectionType)
+timeoutH = EventHandle "timeout" identity
+
+address :: forall connectionType. Socket connectionType -> Effect { port :: Int, family :: IpFamily, address :: String }
+address s = do
+  (runEffectFn1 addressImpl s) <#> \r ->
+    { port: r.port
+    , family: unsafeFromNodeIpFamily r.family
+    , address: r.address
+    }
+
+foreign import addressImpl :: forall connectionType. EffectFn1 (Socket connectionType) ({ port :: Int, family :: String, address :: String })
+
+bytesRead :: forall connectionType. Socket connectionType -> Effect Int
+bytesRead s = runEffectFn1 bytesReadImpl s
+
+foreign import bytesReadImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Int)
+
+bytesWritten :: forall connectionType. Socket connectionType -> Effect Int
+bytesWritten s = runEffectFn1 bytesWrittenImpl s
+
+foreign import bytesWrittenImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Int)
+
+-- | At least `port` must be specified
+createConnectionTCP
+  :: forall r trash
+   . Row.Union r trash (NewSocketOptions (ConnectTcpOptions ()))
+  => { | r }
+  -> Effect (Socket TCP)
+createConnectionTCP o = runEffectFn1 createConnectionImpl o
+
+-- | At least `path` must be specified
+createConnectionIpc
+  :: forall r trash
+   . Row.Union r trash (NewSocketOptions (ConnectIpcOptions ()))
+  => { | r }
+  -> Effect (Socket IPC)
+createConnectionIpc o = runEffectFn1 createConnectionImpl o
+
+foreign import createConnectionImpl :: forall r connectionType. EffectFn1 ({ | r }) (Socket connectionType)
+
+-- | See `ConnectTcpOptions` for options
+connectTcp
+  :: forall r trash
+   . Row.Union r trash (ConnectTcpOptions ())
+  => Socket TCP
+  -> { | r }
+  -> Effect (Socket TCP)
+connectTcp = runEffectFn2 connectTcpImpl
+
+foreign import connectTcpImpl :: forall r. EffectFn2 (Socket TCP) ({ | r }) (Socket TCP)
+
+connectIpc
+  :: Socket IPC
+  -> String
+  -> Effect (Socket IPC)
+connectIpc socket path = runEffectFn2 connectIpcImpl socket path
+
+foreign import connectIpcImpl :: EffectFn2 (Socket IPC) String (Socket IPC)
+
+connecting :: forall connectionType. Socket connectionType -> Effect Boolean
+connecting s = runEffectFn1 connectingImpl s
+
+foreign import connectingImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Boolean)
+
+destroySoon :: forall connectionType. Socket connectionType -> Effect Unit
+destroySoon s = runEffectFn1 destroySoonImpl s
+
+foreign import destroySoonImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Unit)
+
+localAddress :: forall connectionType. Socket connectionType -> Effect String
+localAddress s = runEffectFn1 localAddressImpl s
+
+foreign import localAddressImpl :: forall connectionType. EffectFn1 (Socket connectionType) (String)
+
+localPort :: forall connectionType. Socket connectionType -> Effect Int
+localPort s = runEffectFn1 localPortImpl s
+
+foreign import localPortImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Int)
+
+localFamily :: forall connectionType. Socket connectionType -> Effect IpFamily
+localFamily s = map unsafeFromNodeIpFamily $ runEffectFn1 localFamilyImpl s
+
+foreign import localFamilyImpl :: forall connectionType. EffectFn1 (Socket connectionType) (String)
+
+pending :: forall connectionType. Socket connectionType -> Effect Boolean
+pending s = runEffectFn1 pendingImpl s
+
+foreign import pendingImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Boolean)
+
+ref :: forall connectionType. Socket connectionType -> Effect Unit
+ref s = runEffectFn1 refImpl s
+
+foreign import refImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Unit)
+
+remoteAddress :: forall connectionType. Socket connectionType -> Effect String
+remoteAddress s = runEffectFn1 remoteAddressImpl s
+
+foreign import remoteAddressImpl :: forall connectionType. EffectFn1 (Socket connectionType) (String)
+
+remotePort :: forall connectionType. Socket connectionType -> Effect Int
+remotePort s = runEffectFn1 remotePortImpl s
+
+foreign import remotePortImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Int)
+
+remoteFamily :: forall connectionType. Socket connectionType -> Effect IpFamily
+remoteFamily s = map unsafeFromNodeIpFamily $ runEffectFn1 remoteFamilyImpl s
+
+foreign import remoteFamilyImpl :: forall connectionType. EffectFn1 (Socket connectionType) (String)
+
+resetAndDestroy :: Socket TCP -> Effect Unit
+resetAndDestroy s = runEffectFn1 resetAndDestroyImpl s
+
+foreign import resetAndDestroyImpl :: EffectFn1 (Socket TCP) (Unit)
+
+setKeepAlive :: Socket TCP -> Effect Unit
+setKeepAlive s = runEffectFn1 setKeepAliveImpl s
+
+foreign import setKeepAliveImpl :: EffectFn1 (Socket TCP) (Unit)
+
+setKeepAliveBoolean :: Socket TCP -> Boolean -> Effect Unit
+setKeepAliveBoolean s b = runEffectFn2 setKeepAliveBooleanImpl s b
+
+foreign import setKeepAliveBooleanImpl :: EffectFn2 (Socket TCP) (Boolean) (Unit)
+
+setKeepAliveInitialDelay :: Socket TCP -> Int -> Effect Unit
+setKeepAliveInitialDelay s delay = runEffectFn2 setKeepAliveInitialDelayImpl s delay
+
+foreign import setKeepAliveInitialDelayImpl :: EffectFn2 (Socket TCP) (Int) (Unit)
+
+setKeepAliveAll :: Socket TCP -> Boolean -> Int -> Effect Unit
+setKeepAliveAll s b i = runEffectFn3 setKeepAliveAllImpl s b i
+
+foreign import setKeepAliveAllImpl :: EffectFn3 (Socket TCP) (Boolean) (Int) (Unit)
+
+setNoDelay :: Socket TCP -> Effect Unit
+setNoDelay s = runEffectFn1 setNoDelayImpl s
+
+foreign import setNoDelayImpl :: EffectFn1 (Socket TCP) (Unit)
+
+setNoDelay' :: Socket TCP -> Boolean -> Effect Unit
+setNoDelay' s b = runEffectFn2 setNoDelayBooleanImpl s b
+
+foreign import setNoDelayBooleanImpl :: EffectFn2 (Socket TCP) (Boolean) (Unit)
+
+setTimeout :: forall connectionType. Socket connectionType -> Milliseconds -> Effect Unit
+setTimeout s msecs = runEffectFn2 setTimeoutImpl s msecs
+
+foreign import setTimeoutImpl :: forall connectionType. EffectFn2 (Socket connectionType) (Milliseconds) (Unit)
+
+clearTimeout :: forall connectionType. Socket connectionType -> Effect Unit
+clearTimeout s = setTimeout s (Milliseconds 0.0)
+
+timeout :: forall connectionType. Socket connectionType -> Effect (Maybe Milliseconds)
+timeout s = map toMaybe $ runEffectFn1 timeoutImpl s
+
+foreign import timeoutImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Nullable Milliseconds)
+
+unref :: forall connectionType. Socket connectionType -> Effect Unit
+unref s = runEffectFn1 unrefImpl s
+
+foreign import unrefImpl :: forall connectionType. EffectFn1 (Socket connectionType) (Unit)
+
+readyState :: forall connectionType. Socket connectionType -> Effect SocketReadyState
+readyState s = (runEffectFn1 readyStateImpl s) <#> case _ of
+  "opening" -> Opening
+  "open" -> Open
+  "readOnly" -> ReadOnly
+  "writeOnly" -> WriteOnly
+  x -> unsafeCrashWith $ "Impossible. Unknown socket ready state: " <> show x
+
+foreign import readyStateImpl :: forall connectionType. EffectFn1 (Socket connectionType) (String)

--- a/src/Node/Net/SocketAddress.js
+++ b/src/Node/Net/SocketAddress.js
@@ -1,0 +1,9 @@
+import net from "node:net";
+
+const new_ = (options) => new net.SocketAddress(options);
+export { new_ as newImpl };
+
+export const address = (sa) => sa.address;
+export const familyImpl = (sa) => sa.family;
+export const flowLabelImpl = (sa) => sa.flowLabel;
+export const port = (sa) => sa.port;

--- a/src/Node/Net/SocketAddress.purs
+++ b/src/Node/Net/SocketAddress.purs
@@ -1,0 +1,57 @@
+module Node.Net.SocketAddress
+  ( Ipv4SocketAddressOptions
+  , Ipv6SocketAddressOptions
+  , newIpv4
+  , newIpv6
+  , address
+  , family
+  , flowLabel
+  , port
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, runEffectFn1)
+import Node.Net.Types (IPv4, IPv6, IpFamily(..), SocketAddress, toNodeIpFamily, unsafeFromNodeIpFamily)
+
+-- | `address` <string> The network address as either an IPv4 or IPv6 string. Default: '127.0.0.1' if family is 'ipv4'; '::' if family is 'ipv6'.
+-- | `family` <string> One of either 'ipv4' or 'ipv6'. Default: 'ipv4'.
+-- | `flowlabel` <number> An IPv6 flow-label used only if family is 'ipv6'.
+-- | `port` <number> An IP port.
+type Ipv4SocketAddressOptions =
+  { address :: String
+  , port :: Int
+  }
+
+type Ipv6SocketAddressOptions =
+  { address :: String
+  , flowLabel :: Int
+  , port :: Int
+  }
+
+foreign import newImpl :: forall a b. EffectFn1 { | a } (SocketAddress b)
+
+newIpv4 :: Ipv4SocketAddressOptions -> Effect (SocketAddress IPv4)
+newIpv4 r =
+  runEffectFn1 newImpl { address: r.address, family: toNodeIpFamily IPv4, port: r.port }
+
+newIpv6 :: Ipv6SocketAddressOptions -> Effect (SocketAddress IPv6)
+newIpv6 r =
+  runEffectFn1 newImpl { address: r.address, family: toNodeIpFamily IPv6, flowLabel: r.flowLabel, port: r.port }
+
+foreign import address :: forall ipFamily. SocketAddress ipFamily -> String
+
+family :: forall ipFamily. SocketAddress ipFamily -> IpFamily
+family sa = unsafeFromNodeIpFamily $ familyImpl sa
+
+foreign import familyImpl :: forall ipFamily. SocketAddress ipFamily -> String
+
+flowLabel :: SocketAddress IPv6 -> Maybe Int
+flowLabel = toMaybe <<< flowLabelImpl
+
+foreign import flowLabelImpl :: SocketAddress IPv6 -> Nullable Int
+
+foreign import port :: forall ipFamily. SocketAddress ipFamily -> Int

--- a/src/Node/Net/Types.purs
+++ b/src/Node/Net/Types.purs
@@ -1,0 +1,199 @@
+module Node.Net.Types
+  ( IpFamily(..)
+  , toNodeIpFamily
+  , unsafeFromNodeIpFamily
+  , IPv4
+  , IPv6
+  , SocketAddress
+  , BlockList
+  , ConnectionType
+  , TCP
+  , IPC
+  , Socket
+  , SocketReadyState(..)
+  , socketReadyStateToNode
+  , Server
+  , NewServerOptions
+  , NewSocketOptions
+  , ConnectTcpOptions
+  , ConnectTcpOptionsFamilyOption -- constructor intentionally not exported
+  , familyIpv4
+  , familyIpv6
+  , familyIpv4And6
+  , ConnectIpcOptions
+  , ListenTcpOptions
+  , ListenIpcOptions
+  ) where
+
+import Prelude
+
+import Data.Generic.Rep (class Generic)
+import Data.Time.Duration (Milliseconds)
+import Node.FS (FileDescriptor)
+import Partial.Unsafe (unsafeCrashWith)
+
+data IpFamily
+  -- | Value-level constructor for the IPv4 ip family
+  = IPv4
+  -- | Value-level constructor for the IPv6 ip family
+  | IPv6
+
+derive instance Eq IpFamily
+derive instance Ord IpFamily
+derive instance Generic IpFamily _
+
+instance Show IpFamily where
+  show = case _ of
+    IPv4 -> "IPv4"
+    IPv6 -> "IPv6"
+
+toNodeIpFamily :: IpFamily -> String
+toNodeIpFamily = case _ of
+  IPv4 -> "ipv4"
+  IPv6 -> "ipv6"
+
+unsafeFromNodeIpFamily :: String -> IpFamily
+unsafeFromNodeIpFamily = case _ of
+  "ipv4" -> IPv4
+  "ipv6" -> IPv6
+  "IPv4" -> IPv4
+  "IPv6" -> IPv6
+  x -> unsafeCrashWith $ "Impossible. Unknown ip family: " <> x
+
+-- | Type-level tag for the IPv4 ip family
+foreign import data IPv4 :: IpFamily
+-- | Type-level tag for the IPv6 ip family
+foreign import data IPv6 :: IpFamily
+
+foreign import data SocketAddress :: IpFamily -> Type
+
+foreign import data BlockList :: Type
+
+data ConnectionType
+
+foreign import data IPC :: ConnectionType
+foreign import data TCP :: ConnectionType
+
+-- | `Socket` extends `Duplex` and `EventEmitter`
+foreign import data Socket :: ConnectionType -> Type
+
+data SocketReadyState
+  = Opening
+  | Open
+  | ReadOnly
+  | WriteOnly
+
+derive instance Eq SocketReadyState
+derive instance Generic SocketReadyState _
+
+socketReadyStateToNode :: SocketReadyState -> String
+socketReadyStateToNode = case _ of
+  Opening -> "opening"
+  Open -> "open"
+  ReadOnly -> "readOnly"
+  WriteOnly -> "writeOnly"
+
+-- | `Server` extends `EventEmitter`
+foreign import data Server :: ConnectionType -> Type
+
+-- | `allowHalfOpen` <boolean> If set to false, then the socket will automatically end the writable side when the readable side ends. Default: false.
+-- | `pauseOnConnect` <boolean> Indicates whether the socket should be paused on incoming connections. Default: false.
+-- | `noDelay` <boolean> If set to true, it disables the use of Nagle's algorithm immediately after a new incoming connection is received. Default: false.
+-- | `keepAlive` <boolean> If set to true, it enables keep-alive functionality on the socket immediately after a new incoming connection is received, similarly on what is done in socket.setKeepAlive([enable][, initialDelay]). Default: false.
+-- | `keepAliveInitialDelay` <number> If set to a positive number, it sets the initial delay before the first keepalive probe is sent on an idle socket.Default: 0.
+type NewServerOptions r =
+  ( allowHalfOpen :: Boolean
+  , pauseOnConnect :: Boolean
+  , noDelay :: Boolean
+  , keepAlive :: Boolean
+  , keepAliveInitialDelay :: Number
+  | r
+  )
+
+-- | `fd` <number> If specified, wrap around an existing socket with the given file descriptor, otherwise a new socket will be created.
+-- | `allowHalfOpen` <boolean> If set to false, then the socket will automatically end the writable side when the readable side ends. See net.createServer() and the 'end' event for details. Default: false.
+-- | `readable` <boolean> Allow reads on the socket when an fd is passed, otherwise ignored. Default: false.
+-- | `writable` <boolean> Allow writes on the socket when an fd is passed, otherwise ignored. Default: false.
+type NewSocketOptions r =
+  ( fd :: FileDescriptor
+  , allowHalfOpen :: Boolean
+  , readable :: Boolean
+  , writable :: Boolean
+  | r
+  )
+
+-- | `port` <number> Required. Port the socket should connect to.
+-- | `host` <string> Host the socket should connect to. Default: 'localhost'.
+-- | `localAddress` <string> Local address the socket should connect from.
+-- | `localPort` <number> Local port the socket should connect from.
+-- | `family` <number>: Version of IP stack. Must be 4, 6, or 0. The value 0 indicates that both IPv4 and IPv6 addresses are allowed. Default: 0.
+-- | `noDelay` <boolean> If set to true, it disables the use of Nagle's algorithm immediately after the socket is established. Default: false.
+-- | `keepAlive` <boolean> If set to true, it enables keep-alive functionality on the socket immediately after the connection is established, similarly on what is done in socket.setKeepAlive([enable][, initialDelay]). Default: false.
+-- | `keepAliveInitialDelay` <number> If set to a positive number, it sets the initial delay before the first keepalive probe is sent on an idle socket.Default: 0.
+-- | `autoSelectFamily` <boolean>: If set to true, it enables a family autodetection algorithm that loosely implements section 5 of RFC 8305. The all option passed to lookup is set to true and the sockets attempts to connect to all obtained IPv6 and IPv4 addresses, in sequence, until a connection is established. The first returned AAAA address is tried first, then the first returned A address and so on. Each connection attempt is given the amount of time specified by the autoSelectFamilyAttemptTimeout option before timing out and trying the next address. Ignored if the family option is not 0 or if localAddress is set. Connection errors are not emitted if at least one connection succeeds. Default: false.
+-- | `autoSelectFamilyAttemptTimeout` <number>: The amount of time in milliseconds to wait for a connection attempt to finish before trying the next address when using the autoSelectFamily option. If set to a positive integer less than 10, then the value 10 will be used instead. Default: 250.
+-- |
+-- | Note: `hints` and `lookup` are not supported for now.
+type ConnectTcpOptions r =
+  ( port :: Int
+  , host :: String
+  , localAddress :: String
+  , localPort :: Int
+  , family :: ConnectTcpOptionsFamilyOption
+  -- , hints :: number
+  -- , lookup :: Function
+  , noDelay :: Boolean
+  , keepAlive :: Boolean
+  , keepAliveInitialDelay :: Number
+  , autoSelectFamily :: Boolean
+  , autoSelectFamilyAttemptTimeout :: Milliseconds
+  | r
+  )
+
+newtype ConnectTcpOptionsFamilyOption = ConnectTcpOptionsFamilyOption Int
+
+derive instance Eq ConnectTcpOptionsFamilyOption
+
+familyIpv4 :: ConnectTcpOptionsFamilyOption
+familyIpv4 = ConnectTcpOptionsFamilyOption 4
+
+familyIpv6 :: ConnectTcpOptionsFamilyOption
+familyIpv6 = ConnectTcpOptionsFamilyOption 6
+
+familyIpv4And6 :: ConnectTcpOptionsFamilyOption
+familyIpv4And6 = ConnectTcpOptionsFamilyOption 0
+
+type ConnectIpcOptions r =
+  ( path :: String
+  | r
+  )
+
+-- | port <number>
+-- | host <string>
+-- | backlog <number>  specifies the maximum length of the queue of pending connections. The actual length will be determined by the OS through sysctl settings such as tcp_max_syn_backlog and somaxconn on Linux. The default value of this parameter is 511 (not 512).
+-- | exclusive <boolean> Default: false
+-- | ipv6Only <boolean> For TCP servers, setting ipv6Only to true will disable dual-stack support, i.e., binding to host :: won't make 0.0.0.0 be bound. Default: false.
+type ListenTcpOptions r =
+  ( port :: Int
+  , host :: String
+  , backlog :: Int
+  , exclusive :: Boolean
+  , ipv6Only :: Boolean
+  | r
+  )
+
+-- | host <string>
+-- | path <string>
+-- | backlog <number> specifies the maximum length of the queue of pending connections. The actual length will be determined by the OS through sysctl settings such as tcp_max_syn_backlog and somaxconn on Linux. The default value of this parameter is 511 (not 512).
+-- | exclusive <boolean> Default: false
+-- | readableAll <boolean> makes the pipe readable for all users. Default: false.
+-- | writableAll <boolean> makes the pipe writable for all users. Default: false.
+type ListenIpcOptions r =
+  ( host :: String
+  , path :: String
+  , backlog :: Int
+  , exclusive :: Boolean
+  , readableAll :: Boolean
+  , writableAll :: Boolean
+  | r
+  )

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -41,7 +41,7 @@ main = do
           false -> infoShow { _message: "Socket closed without an error" }
           true -> errorShow { _message: "Socket closed with an error" }
         Node.Net.Socket.onConnect socket do
-          infoShow {_message: "Socket connected"}
+          infoShow { _message: "Socket connected" }
         Node.Net.Socket.onData socket case _ of
           Left buffer -> do
             bufferString <- toString UTF8 buffer

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -2,72 +2,73 @@ module Test.Main (main) where
 
 import Prelude
 
-import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Console (errorShow, infoShow, logShow)
 import Node.Buffer (toString)
 import Node.Encoding (Encoding(..))
-import Node.Net.Server as Node.Net.Server
-import Node.Net.Socket as Node.Net.Socket
+import Node.EventEmitter (on_)
+import Node.Net.Server as Server
+import Node.Net.Socket as Socket
+import Node.Stream as Stream
 
 main :: Effect Unit
 main = do
-  server <- Node.Net.Server.createServer mempty \socket -> do
+  server <- Server.createTcpServer
+  server # on_ Server.connectionH \socket -> do
+    let sDuplex = Socket.toDuplex socket
     infoShow { _message: "Server received connection" }
-    void $ Node.Net.Socket.writeString socket "Hello socket\n" UTF8 mempty
-    Node.Net.Socket.endString socket "Server is ending connection\n" UTF8 mempty
+    void $ Stream.writeString sDuplex UTF8 "Hello socket\n" mempty
+    void $ Stream.writeString sDuplex UTF8 "Server is ending connection\n" mempty
+    Stream.end sDuplex mempty
 
-  Node.Net.Server.onClose server do
+  server # on_ Server.closeH do
     infoShow { _message: "Server closed" }
-  Node.Net.Server.onConnection server \socket -> do
-    addr <- Node.Net.Socket.localAddress socket
-    port <- Node.Net.Socket.localPort socket
+  server # on_ Server.connectionH \socket -> do
+    addr <- Socket.localAddress socket
+    port <- Socket.localPort socket
     infoShow { _message: "Connection successfully made", addr, port }
-  Node.Net.Server.onError server \err -> do
+  server # on_ Server.errorH \err -> do
     infoShow { _message: "Server had an error", err }
-  Node.Net.Server.onListening server do
+  server # on_ Server.listeningH do
     infoShow { _message: "Server is listening" }
 
-  Node.Net.Server.listenTCP server 0 "localhost" 511 do
-    addr <- Node.Net.Server.address server
+  Server.listenTcp server { port: 0, host: "localhost" }
+  server # on_ Server.listeningH do
+    addr <- Server.addressTcp server
     infoShow { _message: "Opened server", addr }
     case addr of
-      Just (Left { port }) -> do
-        socket <- Node.Net.Socket.createConnectionTCP port "localhost" do
+      Nothing ->
+        Server.close server
+      Just { port } -> do
+        socket <- Socket.createConnectionTCP { port, host: "localhost" }
+        let sDuplex = Socket.toDuplex socket
+        socket # on_ Socket.connectH do
           infoShow { _message: "Connected to server" }
 
-        Node.Net.Socket.onClose socket case _ of
+        socket # on_ Socket.closeH case _ of
           false -> infoShow { _message: "Socket closed without an error" }
           true -> errorShow { _message: "Socket closed with an error" }
-        Node.Net.Socket.onConnect socket do
+        socket # on_ Socket.connectH do
           infoShow { _message: "Socket connected" }
-        Node.Net.Socket.onData socket case _ of
-          Left buffer -> do
-            bufferString <- toString UTF8 buffer
-            logShow { _message: "Received some data", bufferString }
-          Right string -> logShow { _message: "Received some data", string }
-        Node.Net.Socket.onDrain socket do
-          infoShow { _message: "Socket drained" }
-        Node.Net.Socket.onEnd socket do
+        Stream.onData sDuplex \buffer -> do
+          bufferString <- toString UTF8 buffer
+          logShow { _message: "Received some data", bufferString }
+        Stream.onEnd sDuplex do
           infoShow { _message: "Socket ended, closing server" }
-          Node.Net.Server.close server mempty
-        Node.Net.Socket.onError socket \err ->
+          Server.close server
+        Stream.onError sDuplex \err ->
           errorShow { _message: "Socket had an error", err }
-        Node.Net.Socket.onLookup socket case _ of
-          Left err ->
-            infoShow { _message: "Socket had an error resolving DNS", err }
-          Right lookup ->
-            infoShow { _message: "Socket successfully resolved DNS", lookup }
-        Node.Net.Socket.onReady socket do
+        socket # on_ Socket.lookupH \err address family host ->
+          case err of
+            Just err' ->
+              infoShow { _message: "Socket had an error resolving DNS", err: err' }
+            Nothing ->
+              infoShow { _message: "Socket successfully resolved DNS", address, family, host }
+        socket # on_ Socket.readyH do
           infoShow { _message: "Socket is ready" }
-          void $ Node.Net.Socket.writeString socket "Hello server" UTF8 mempty
-        Node.Net.Socket.onTimeout socket do
+          void $ Stream.writeString sDuplex UTF8 "Hello server" mempty
+        socket # on_ Socket.timeoutH do
           infoShow { _message: "Socket timed out" }
-          Node.Net.Socket.endString socket "Closing connection" UTF8 mempty
-
-      Just (Right endpoint) -> do
-        errorShow { _message: "Server unexpectedly connected over ICP" }
-        Node.Net.Server.close server mempty
-
-      _ -> Node.Net.Server.close server mempty
+          void $ Stream.writeString sDuplex UTF8 "Closing connection" mempty
+          Stream.end sDuplex mempty


### PR DESCRIPTION
**Description of the change**

- Format via purs-tidy
- Add dependency on node-event-emitter
- Fully implement net bindings
    - Added bindings for `BlockList` and `SocketAddress`
    - Worked around Socket TCP/IPC issue by forcing user to specify which connection type they'll use it for when creating the socket
    - Defined rows for connect/listen options as these are sometimes used in the `http2` `connect` function.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
